### PR TITLE
No knockback

### DIFF
--- a/Reforge.cs
+++ b/Reforge.cs
@@ -24,6 +24,13 @@ namespace BetterReforges
             }
 
             if (item.maxStack == 0 || item.damage > 0 || item.useStyle != 0) {
+
+                if (item.hammer > 0 || item.pick > 0 || item.axe > 0)
+                {
+                    int index = rand.Next(0, toolModifiers.Length);
+                    return toolModifiers[index];
+                }
+
                 if (item.melee)
                 {
                     if ( item.knockBack > 0 )
@@ -78,11 +85,6 @@ namespace BetterReforges
                     return thrownModifiers[index];
                 }
 
-                if (item.hammer > 0 || item.pick > 0 || item.axe > 0)
-                {
-                    int index = rand.Next(0, toolModifiers.Length);
-                    return thrownModifiers[index];
-                }
             }
 
             return -1;

--- a/Reforge.cs
+++ b/Reforge.cs
@@ -1,4 +1,4 @@
-﻿using Terraria;
+using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.Utilities;
@@ -26,35 +26,43 @@ namespace BetterReforges
             if (item.maxStack == 0 || item.damage > 0 || item.useStyle != 0) {
                 if (item.melee)
                 {
-                    if ( knockBack > 0 )
-                    {
-                        int index = rand.Next(0, noKnockbackModifiers.Length);
-                        return noKnockbackModifiers[index];
-                    } 
-                    else
+                    if ( item.knockBack > 0 )
                     {
                         int index = rand.Next(0, meleeModifiers.Length);
                         return meleeModifiers[index];
+                    }
+                    else
+                    {
+                        int index = rand.Next(0, noKnockbackModifiers.Length);
+                        return noKnockbackModifiers[index];
                     }
                 }
 
                 if (item.ranged)
                 {
-                    int index = rand.Next(0, rangeModifiers.Length);
-                    return rangeModifiers[index];
+                    if (item.knockBack > 0)
+                    {
+                        int index = rand.Next(0, rangeModifiers.Length);
+                        return rangeModifiers[index];
+                    }
+                    else
+                    {
+                        int index = rand.Next(0, noKnockbackModifiers.Length);
+                        return noKnockbackModifiers[index];
+                    }
                 }
 
                 if (item.magic)
                 {
-                    if ( knockBack > 0 )
-                    {
-                        int index = rand.Next(0, noKnockbackModifiers.Length);
-                        return noKnockbackModifiers[index];
-                    } 
-                    else
+                    if ( item.knockBack > 0 )
                     {
                         int index = rand.Next(0, mageModifiers.Length);
                         return mageModifiers[index];
+                    } 
+                    else
+                    {
+                        int index = rand.Next(0, noKnockbackModifiers.Length);
+                        return noKnockbackModifiers[index];
                     }
                 }
 

--- a/Reforge.cs
+++ b/Reforge.cs
@@ -14,6 +14,7 @@ namespace BetterReforges
         static int[] summonerModifiers = { PrefixID.Mythical };
         static int[] toolModifiers = { PrefixID.Light };
         static int[] thrownModifiers = { PrefixID.Legendary };
+        static int[] noKnockbackModifiers = { PrefixID.Demonic};
 
         public override int ChoosePrefix(Item item, UnifiedRandom rand) {
             if (item.accessory)
@@ -25,8 +26,16 @@ namespace BetterReforges
             if (item.maxStack == 0 || item.damage > 0 || item.useStyle != 0) {
                 if (item.melee)
                 {
-                    int index = rand.Next(0, meleeModifiers.Length);
-                    return meleeModifiers[index];
+                    if ( knockBack > 0 )
+                    {
+                        int index = rand.Next(0, noKnockbackModifiers.Length);
+                        return noKnockbackModifiers[index];
+                    } 
+                    else
+                    {
+                        int index = rand.Next(0, meleeModifiers.Length);
+                        return meleeModifiers[index];
+                    }
                 }
 
                 if (item.ranged)
@@ -37,8 +46,16 @@ namespace BetterReforges
 
                 if (item.magic)
                 {
-                    int index = rand.Next(0, mageModifiers.Length);
-                    return mageModifiers[index];
+                    if ( knockBack > 0 )
+                    {
+                        int index = rand.Next(0, noKnockbackModifiers.Length);
+                        return noKnockbackModifiers[index];
+                    } 
+                    else
+                    {
+                        int index = rand.Next(0, mageModifiers.Length);
+                        return mageModifiers[index];
+                    }
                 }
 
                 if (item.summon)


### PR DESCRIPTION
Added check for **knockback**, because weapons without knockback cannot have certain modifiers.
Changed check order; tools now get "light" modifier. Some low tools (copper tools, wooden hammer) can't have "legendary" modifier.